### PR TITLE
Add forceElevated and elevation properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     alt="Platform" />
 </a>
 <a href="https://pub.dev/packages/sliver_snap">
-  <img src="https://img.shields.io/badge/pub-1.1.1-blue"
+  <img src="https://img.shields.io/badge/pub-1.2.0-blue"
     alt="Pub Package" />
 </a>
 <a href="https://github.com/A-Fawzyy/sliver-snap/blob/main/LICENSE">
@@ -59,7 +59,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  sliver_snap: ^1.1.1
+  sliver_snap: ^1.2.0
 ```
 
 or you can add the latest version from the command line:
@@ -146,7 +146,8 @@ import 'package:sliver_snap/sliver_snap.dart';
 | scrollController          | ScrollController?        | N/A              | Can be used to pass your own `scrollController` to customize the appbar even more.                                                                                                                                                                                                                                                                                                                                                                 |
 | scrollBehavior            | ScrollBehaviour?         | N/A              | How the scrollable widgets behave, either `Material` or `Cupertino` Scrolling behaviors.                                                                                                                                                                                                                                                                                                                                                           |
 | onCollapseStateChanged    | CollapsingStateCallback? | N/A              | This is a callback function that is triggered when the bar is either collapsed or expanded. It can be used to customize the animation and behavior of the widget to better suit your needs.                                                                                                                                                                                                                                                        |
-
+| elevation                 | double                   | 0.0              | The elevation of the app bar                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| forceElevated             | bool                     | false            | Whether to show the shadow appropriate for the `elevation` even if the content is not scrolled under the app bar. Defaults to false, meaning that the `elevation` is only applied when the app bar is being displayed over content that is scrolled under it.                                                                                                                                                                                      |
 
 # Extra Components
 

--- a/lib/widgets/sliver_snap.dart
+++ b/lib/widgets/sliver_snap.dart
@@ -172,6 +172,22 @@ class SliverSnap extends HookWidget {
   /// Defaults to [Curves.easeInOut]
   final Curve? animationCurve;
 
+  /// Whether to show the shadow appropriate for the [elevation] even if the
+  /// content is not scrolled under the [AppBar].
+  ///
+  /// Defaults to false, meaning that the [elevation] is only applied when the
+  /// [AppBar] is being displayed over content that is scrolled under it.
+  ///
+  /// When set to true, the [elevation] is applied regardless.
+  ///
+  /// Ignored when [elevation] is zero.
+  final bool forceElevated;
+
+  /// The elevation of the app bar.
+  ///
+  /// Defaults to `0.0`
+  final double elevation;
+
   const SliverSnap({
     super.key,
     required this.expandedContent,
@@ -195,6 +211,8 @@ class SliverSnap extends HookWidget {
     this.scrollBehavior,
     this.onCollapseStateChanged,
     this.automaticallyImplyLeading = false,
+    this.forceElevated = false,
+    this.elevation = 0.0,
   });
 
   @override
@@ -255,6 +273,8 @@ class SliverSnap extends HookWidget {
         collapsedBackgroundColor: collapsedBackgroundColor,
         expandedBackgroundColor: expandedBackgroundColor,
         isCollapsed: isCollapsedValueNotifier.value,
+        forceElevated: forceElevated,
+        elevation: elevation,
       ),
     );
   }

--- a/lib/widgets/snapping_app_bar_body.dart
+++ b/lib/widgets/snapping_app_bar_body.dart
@@ -22,6 +22,8 @@ class SnappingAppBarBody extends StatelessWidget {
     this.bottom,
     this.isCollapsed = false,
     this.automaticallyImplyLeading = false,
+    this.elevation = 0,
+    this.forceElevated = false,
   });
 
   final ScrollController scrollController;
@@ -44,6 +46,8 @@ class SnappingAppBarBody extends StatelessWidget {
   final Color? expandedBackgroundColor;
   final ScrollBehavior? scrollBehavior;
   final bool automaticallyImplyLeading;
+  final bool forceElevated;
+  final double? elevation;
 
   @override
   Widget build(BuildContext context) {
@@ -64,7 +68,8 @@ class SnappingAppBarBody extends StatelessWidget {
               collapsedHeight: collapsedBarHeight,
               centerTitle: false,
               pinned: pinned,
-              elevation: 0,
+              elevation: elevation,
+              forceElevated: forceElevated,
               title: AnimatedOpacity(
                 duration: const Duration(milliseconds: 200),
                 opacity: isCollapsed ? 1 : 0,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sliver_snap
 description: Allows you to use powerful snapping slivers with expanded and collapsed bars.
-version: 1.1.1
+version: 1.2.0
 repository: https://github.com/A-Fawzyy/sliver-snap
 issue_tracker: https://github.com/A-Fawzyy/sliver-snap/issues
 


### PR DESCRIPTION
This PR adds two new properties, `forceElevated` and `elevation`, to both the `SliverSnap` and `SnappingAppBarBody` classes. The `forceElevated` property determines whether or not to show the shadow appropriate for the elevation even if the content is not scrolled under the app bar. The default value of this property is false. The `elevation` property sets the elevation of the app bar, with a default value of 0.0. These changes will allow for more customization options when using these widgets in an app.